### PR TITLE
Remove returning error message when observer-context is null

### DIFF
--- a/native/src/main/java/io/ballerina/stdlib/observe/nativeimpl/OpenTracerBallerinaWrapper.java
+++ b/native/src/main/java/io/ballerina/stdlib/observe/nativeimpl/OpenTracerBallerinaWrapper.java
@@ -185,9 +185,6 @@ public class OpenTracerBallerinaWrapper {
             ObserverContext observer = ObserveUtils.getObserverContextOfCurrentFrame(env);
             if (observer == null) {
                 return null;
-//                return ErrorCreator.createError(
-//                        StringUtils.fromString(
-//                                ("Span already finished. Can not add tag {" + tagKey + ":" + tagValue + "}")));
             }
             span = observer.getSpan();
         } else {

--- a/native/src/main/java/io/ballerina/stdlib/observe/nativeimpl/OpenTracerBallerinaWrapper.java
+++ b/native/src/main/java/io/ballerina/stdlib/observe/nativeimpl/OpenTracerBallerinaWrapper.java
@@ -184,6 +184,9 @@ public class OpenTracerBallerinaWrapper {
         if (spanId == -1) {
             ObserverContext observer = ObserveUtils.getObserverContextOfCurrentFrame(env);
             if (observer == null) {
+                // This is a case where the user has not started the tracing.
+                // ObserverContext will be null if function is executed without entry point like main or resource
+                // function ex. initialising phase.
                 return null;
             }
             span = observer.getSpan();

--- a/native/src/main/java/io/ballerina/stdlib/observe/nativeimpl/OpenTracerBallerinaWrapper.java
+++ b/native/src/main/java/io/ballerina/stdlib/observe/nativeimpl/OpenTracerBallerinaWrapper.java
@@ -184,9 +184,10 @@ public class OpenTracerBallerinaWrapper {
         if (spanId == -1) {
             ObserverContext observer = ObserveUtils.getObserverContextOfCurrentFrame(env);
             if (observer == null) {
-                return ErrorCreator.createError(
-                        StringUtils.fromString(
-                                ("Span already finished. Can not add tag {" + tagKey + ":" + tagValue + "}")));
+                return null;
+//                return ErrorCreator.createError(
+//                        StringUtils.fromString(
+//                                ("Span already finished. Can not add tag {" + tagKey + ":" + tagValue + "}")));
             }
             span = observer.getSpan();
         } else {


### PR DESCRIPTION
## Purpose
When observability enabled and the project contains global variables declared (or init() functions) with client invokes, the following error occurs in the ballerina runtime.

```
ballerina: started publishing traces to Jaeger on localhost:55680
ballerina: started Prometheus HTTP listener 0.0.0.0:9797
https://api.asgardeo.io/t/bifrost/oauth2/token/.well-known/openid-configurationerror: client method invocation failed: Span already finished. Can not add tag {http.url:/}
```

The reason for error is that the spans are created only after declaring variables. Spans won't be created for init() functions as well. Therefore we have to skip returning errors for this scenario. 

Also `observer context` is null only at initializing variables.

### Fixes https://github.com/ballerina-platform/ballerina-lang/issues/41966, https://github.com/wso2-enterprise/internal-support-ballerina/issues/556
