### PR TITLE
Remove returning error message when `ObserverContext` is `null` while adding tags to Metrics

### DIFF
--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "ballerina"
 name = "observe"
-version = "1.2.1"
+version = "1.2.2"
 distribution = "2201.8.0"
 export = ["observe", "observe.mockextension" ]
 
@@ -9,7 +9,7 @@ export = ["observe", "observe.mockextension" ]
 graalvmCompatible = true
 
 [[platform.java17.dependency]]
-path = "../native/build/libs/observe-native-1.2.1.jar"
+path = "../native/build/libs/observe-native-1.2.2-SNAPSHOT.jar"
 groupId = "ballerina"
 artifactId = "observe"
 

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -18,7 +18,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "observe"
-version = "1.2.1"
+version = "1.2.2"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]

--- a/native/src/main/java/io/ballerina/stdlib/observe/nativeimpl/AddTagToMetrics.java
+++ b/native/src/main/java/io/ballerina/stdlib/observe/nativeimpl/AddTagToMetrics.java
@@ -48,6 +48,8 @@ public class AddTagToMetrics {
             observerContext.customMetricTags.put(tagKey.getValue(), Tag.of(tagKey.getValue(), tagValue.getValue()));
             return null;
         }
+        // ObserverContext will be null if function is executed without entry point like main or resource
+        // function ex. initialising phase.
         return null;
     }
 }

--- a/native/src/main/java/io/ballerina/stdlib/observe/nativeimpl/AddTagToMetrics.java
+++ b/native/src/main/java/io/ballerina/stdlib/observe/nativeimpl/AddTagToMetrics.java
@@ -20,8 +20,6 @@
 package io.ballerina.stdlib.observe.nativeimpl;
 
 import io.ballerina.runtime.api.Environment;
-import io.ballerina.runtime.api.creators.ErrorCreator;
-import io.ballerina.runtime.api.utils.StringUtils;
 import io.ballerina.runtime.api.values.BString;
 import io.ballerina.runtime.observability.ObserveUtils;
 import io.ballerina.runtime.observability.ObserverContext;
@@ -50,7 +48,6 @@ public class AddTagToMetrics {
             observerContext.customMetricTags.put(tagKey.getValue(), Tag.of(tagKey.getValue(), tagValue.getValue()));
             return null;
         }
-        return ErrorCreator.createError(
-                StringUtils.fromString("Can not add tag {" + tagKey + ":" + tagValue + "}"));
+        return null;
     }
 }


### PR DESCRIPTION
When observability enabled and the project contains global variables declared (or init() functions) with client invokes, the following error occurs in the ballerina runtime.

```
ballerina: started publishing traces to Jaeger on localhost:55680
ballerina: started Prometheus HTTP listener 0.0.0.0:9797
error: client method invocation failed: Can not add tag {http.method:GET}
```

We do not need to return error when the `Observer Context` is `null` (i.e. Observer Context is null only in the initializing phase). Other than that, observability features should not affect the application as well (Should only return warning logs or error logs).

With this PR, `null` value will be returned instead of returning an error when Observer Context is null.

###Fixes https://github.com/ballerina-platform/ballerina-lang/issues/41966
