### PR TITLE
Add configuration for enabling observability logs

### DIFF
--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "ballerina"
 name = "observe"
-version = "1.3.0"
+version = "1.4.0"
 distribution = "2201.10.0"
 export = ["observe", "observe.mockextension" ]
 
@@ -9,7 +9,7 @@ export = ["observe", "observe.mockextension" ]
 graalvmCompatible = true
 
 [[platform.java17.dependency]]
-path = "../native/build/libs/observe-native-1.3.0.jar"
+path = "../native/build/libs/observe-native-1.4.0-SNAPSHOT.jar"
 groupId = "ballerina"
 artifactId = "observe"
 

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -18,7 +18,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "observe"
-version = "1.3.0"
+version = "1.4.0"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]

--- a/ballerina/commons.bal
+++ b/ballerina/commons.bal
@@ -23,7 +23,7 @@ configurable boolean metricsEnabled = false;
 configurable string metricsReporter = "";
 configurable boolean tracingEnabled = false;
 configurable string tracingProvider = "";
-configurable boolean observabilityLogsEnabled = false;
+configurable boolean metricsLogsEnabled = false;
 
 function init() returns error? {
     boolean isMissingMetricsReporter = ((enabled || metricsEnabled) && (provider == "" && metricsReporter == ""));

--- a/ballerina/commons.bal
+++ b/ballerina/commons.bal
@@ -23,6 +23,7 @@ configurable boolean metricsEnabled = false;
 configurable string metricsReporter = "";
 configurable boolean tracingEnabled = false;
 configurable string tracingProvider = "";
+configurable boolean observabilityLogsEnabled = false;
 
 function init() returns error? {
     boolean isMissingMetricsReporter = ((enabled || metricsEnabled) && (provider == "" && metricsReporter == ""));

--- a/gradle.properties
+++ b/gradle.properties
@@ -14,7 +14,7 @@
 
 org.gradle.caching=true
 group=io.ballerina.stdlib
-version=1.3.1-SNAPSHOT
+version=1.4.0-SNAPSHOT
 ballerinaLangVersion=2201.10.0
 githubSpotbugsVersion=5.0.14
 githubJohnrengelmanShadowVersion=8.1.1


### PR DESCRIPTION
## Purpose
We need to add observability logs to provide response time in seconds for each response. This should be configured in the runtime. Therefore we need to add a configuration in the observe module.

Fixes https://github.com/ballerina-platform/ballerina-lang/issues/43478

## Examples

## Checklist
- [ ] Linked to an issue
- [ ] Updated the changelog
- [ ] Added tests