### PR TITLE
Fix CVE-2026-45292: upgrade opentelemetry-api to 1.63.0

### DIFF
--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -33,6 +33,6 @@ artifactId = "opentelemetry-sdk-common"
 version = "1.63.0"
 
 [[platform.java21.dependency]]
-groupId = "io.opentelemetry"
+groupId = "io.opentelemetry.semconv"
 artifactId = "opentelemetry-semconv"
-version = "1.63.0-alpha"
+version = "1.27.0"

--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "ballerina"
 name = "observe"
-version = "1.7.1"
+version = "1.7.2"
 distribution = "2201.13.2"
 
 [[package.modules]]
@@ -13,26 +13,26 @@ export = true
 graalvmCompatible = true
 
 [[platform.java21.dependency]]
-path = "../native/build/libs/observe-native-1.7.1.jar"
+path = "../native/build/libs/observe-native-1.7.2-SNAPSHOT.jar"
 groupId = "ballerina"
 artifactId = "observe"
 
 [[platform.java21.dependency]]
 groupId = "io.opentelemetry"
 artifactId = "opentelemetry-sdk-trace"
-version = "1.0.0"
+version = "1.63.0"
 
 [[platform.java21.dependency]]
 groupId = "io.opentelemetry"
 artifactId = "opentelemetry-sdk-testing"
-version = "1.0.0"
+version = "1.63.0"
 
 [[platform.java21.dependency]]
 groupId = "io.opentelemetry"
 artifactId = "opentelemetry-sdk-common"
-version = "1.0.0"
+version = "1.63.0"
 
 [[platform.java21.dependency]]
 groupId = "io.opentelemetry"
 artifactId = "opentelemetry-semconv"
-version = "1.0.0-alpha"
+version = "1.63.0-alpha"

--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -31,8 +31,3 @@ version = "1.63.0"
 groupId = "io.opentelemetry"
 artifactId = "opentelemetry-sdk-common"
 version = "1.63.0"
-
-[[platform.java21.dependency]]
-groupId = "io.opentelemetry.semconv"
-artifactId = "opentelemetry-semconv"
-version = "1.27.0"

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -18,7 +18,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "observe"
-version = "1.7.1"
+version = "1.7.2"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]

--- a/build-config/resources/Ballerina.toml
+++ b/build-config/resources/Ballerina.toml
@@ -31,8 +31,3 @@ version = "@opentelemetry.version@"
 groupId = "io.opentelemetry"
 artifactId = "opentelemetry-sdk-common"
 version = "@opentelemetry.version@"
-
-[[platform.java21.dependency]]
-groupId = "io.opentelemetry"
-artifactId = "opentelemetry-semconv"
-version = "@opentelemetry.version@-alpha"

--- a/gradle.properties
+++ b/gradle.properties
@@ -24,7 +24,7 @@ releasePluginVersion=2.8.0
 ballerinaTomlParserVersion=1.2.2
 ballerinaGradlePluginVersion=2.3.0
 checkstylePluginVersion=10.12.1
-openTelemetryVersion=1.0.0
+openTelemetryVersion=1.63.0
 gsonVersion=2.8.9
 
 # Test Dependency Versions


### PR DESCRIPTION
## Summary
- Bumps `opentelemetry-api` from 1.0.0 to 1.63.0 to fix CVE-2026-45292 (Unbounded Memory Allocation in W3C Baggage Propagation — DoS vulnerability in \`W3CBaggagePropagator\`)
- Co-bumps \`opentelemetry-sdk-trace\`, \`opentelemetry-sdk-testing\`, \`opentelemetry-sdk-common\` (driven by the same \`openTelemetryVersion\` variable; stable public APIs with no breaking changes)
- Removes unused \`opentelemetry-semconv\` platform dependency from \`build-config/resources/Ballerina.toml\` template (no semconv imports exist anywhere in Java or Ballerina source; artifact also no longer published under the old \`io.opentelemetry\` group ID)
- No Java source changes required: all OTel API classes used (\`Tracer\`, \`SdkTracerProvider\`, \`InMemorySpanExporter\`, \`SimpleSpanProcessor\`, \`SpanData\`, \`Attributes\`) are stable and present unchanged in 1.63.0

Fixes https://github.com/ballerina-platform/ballerina-lang/issues/44622

## CVE Reference
- [CVE-2026-45292](https://github.com/advisories/GHSA-rcgg-9c38-7xpx)
- Affected versions: ≤ 1.61.0 | Fixed in: 1.62.0+

## Test plan
- [x] Local \`./gradlew build\` passed — 15/15 tests passed
- [x] Java source imports verified compatible with 1.63.0 (no code changes needed)
- [x] Confirmed \`opentelemetry-semconv\` has zero imports in Java/Ballerina source before removal